### PR TITLE
Update metadata.txt about the server flag

### DIFF
--- a/solar_pw_calculator/metadata.txt
+++ b/solar_pw_calculator/metadata.txt
@@ -43,5 +43,5 @@ Category of the plugin: Raster, Vector, Database or Web
 # category=Vector
 
 # If the plugin can run on QGIS Server.
-server=True
+server=False
 


### PR DESCRIPTION
You have tagged this plugin to be a QGIS server plugin, we can see it here : https://plugins.qgis.org/plugins/server/
I think it's a mistake ?

https://github.com/ahmetyavuzd/SPAN/blob/main/solar_pw_calculator/__init__.py I do not see a entry point for QGIS server.